### PR TITLE
Manage artifact consumption in plugin (vs reporter)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1303,9 +1303,9 @@
       }
     },
     "eth-gas-reporter": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.2.tgz",
-      "integrity": "sha512-+KJC2r6U8W6qeLI24kBglt4H+MR20DcSy3/iYGNXhjLUD/D+EnH8TLsMjgOIBfLITnUfmSHV11+08JmSd+uO/A==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.3.tgz",
+      "integrity": "sha512-1R5eK5t+JGAjlCAensFsduwouf5Mi7wXMbCPr6NSiup6A9Ie1cQW5pd6oupB0kwADSDxaDu86CZE17y0Fs/8Gg==",
       "requires": {
         "abi-decoder": "^1.2.0",
         "cli-table3": "^0.5.0",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,6 @@
     "@nomiclabs/buidler": "^1.0.0-beta.8"
   },
   "dependencies": {
-    "eth-gas-reporter": "^0.2.2"
+    "eth-gas-reporter": "^0.2.3"
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,6 @@ export interface EthGasReporterConfig {
   // Buidler (required)
   enabled: boolean;
   metadata: any;
-  artifactType: string;
+  artifactType: any;
   url: string;
 }


### PR DESCRIPTION
Supplies reporter with artifact handler which should work for truffle and non-truffle buidler projects. 

Still having problems integrating the ethers example project with the tests here but believe this should resolve #6... 