### PR TITLE
Fix ethers tests

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+TS_NODE_FILES=true

--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,7 @@ typings/
 # buidler-project
 test/buidler-truffle-project/artifacts
 test/buidler-truffle-project/cache
+test/buidler-ethers-project/artifacts
+test/buidler-ethers-project/cache
 dist/
 

--- a/test/buidler-ethers-project/test/greeter.ts
+++ b/test/buidler-ethers-project/test/greeter.ts
@@ -1,9 +1,10 @@
 // tslint:disable-next-line no-implicit-dependencies
 import { assert } from "chai";
+import { ethers } from "@nomiclabs/buidler";
 
-describe.skip("Greeter contract", function() {
-  /*it("Should shoud be deployable with different greetings", async function() {
-    const Greeter = await this.env.ethers.getContract("Greeter");
+describe("Greeter contract", function() {
+  it("Should shoud be deployable with different greetings", async function() {
+    const Greeter = await ethers.getContract("Greeter");
     const greeter1 = await Greeter.deploy("Hi");
     assert.equal(await greeter1.functions.greeting(), "Hi");
 
@@ -12,9 +13,9 @@ describe.skip("Greeter contract", function() {
   });
 
   it("Should return the greeting when greet is called", async function() {
-    const Greeter = await this.env.ethers.getContract("Greeter");
+    const Greeter = await ethers.getContract("Greeter");
     const greeter1 = await Greeter.deploy("Hi");
 
     assert.equal(await greeter1.functions.greet(), "Hi");
-  });*/
+  });
 });

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,4 +1,4 @@
 --require dotenv/config
 --require ts-node/register
 --require source-map-support/register
---recursive test/**/*.ts
+--recursive test/tests.ts

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -7,7 +7,7 @@ import { useEnvironment } from "./helpers";
 // Only one of these tests can be run for now. TASK_TEST kills the process
 // after running mocha. This should be fixed in Buidler v1.0.0-beta.9
 
-describe.skip("Gas Reporter (Truffle plugin)", function() {
+describe("Gas Reporter (Truffle plugin)", function() {
   useEnvironment(__dirname + "/buidler-truffle-project");
 
   it("using option - onlyCalledMethods: false", async function() {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -15,7 +15,7 @@ describe("Gas Reporter (Truffle plugin)", function() {
   });
 });
 
-describe("Gas Reporter (Ethers plugin)", function() {
+describe.skip("Gas Reporter (Ethers plugin)", function() {
   useEnvironment(__dirname + "/buidler-ethers-project");
 
   it("no options", async function() {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -4,7 +4,10 @@ import { assert } from "chai";
 
 import { useEnvironment } from "./helpers";
 
-describe("Gas Reporter (Truffle plugin)", function() {
+// Only one of these tests can be run for now. TASK_TEST kills the process
+// after running mocha. This should be fixed in Buidler v1.0.0-beta.9
+
+describe.skip("Gas Reporter (Truffle plugin)", function() {
   useEnvironment(__dirname + "/buidler-truffle-project");
 
   it("using option - onlyCalledMethods: false", async function() {
@@ -12,10 +15,7 @@ describe("Gas Reporter (Truffle plugin)", function() {
   });
 });
 
-// This test has a typescript compilation error complaining that
-// it can't resolve ethers from @nomiclabs/buidler. Base project
-// (ethers-example) works fine on its own though.
-describe.skip("Gas Reporter (Ethers plugin)", function() {
+describe("Gas Reporter (Ethers plugin)", function() {
   useEnvironment(__dirname + "/buidler-ethers-project");
 
   it("no options", async function() {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,8 @@
   "include": [
     "./test",
     "./src"
+  ],
+  "files": [
+    "node_modules/@nomiclabs/buidler-ethers/src/type-extensions.d.ts"
   ]
 }


### PR DESCRIPTION
I (mostly) fixed the ethers tests.

There were a few issues:

1. When using `ts` you need to include their type extension's in the `tsconfig.json`. This should be clear in the docs, sorry.
2. `ts-node` normally ignores parts of `tsconfig.json`. To make it work more like `tsc` you have to set the env variable `TS_NODE_FILES` to `true`. I did that with a `.env` file.
3. The Buidler Runtime Environment can/should be imported directly from Buidler project's tests. The `this.env` thing is for testing the plugin itself. It's defined by the `useEnvironment` helper.
4. Mocha was trying to run all the tests, including the Buidler projects' ones. I set it to only run the top-level ones.

Finally, I found an issue with Buidler :( It kills the process after running `TASK_TEST`, so only one of the projects can be run at the time. I will fix this in the next version.

Thanks a lot for creating this plugin!