### PR TITLE
Track gas by wrapping BuidlerEVM provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "@nomiclabs/buidler": "^1.0.1"
   },
   "dependencies": {
-    "eth-gas-reporter": "^0.2.17"
+    "eth-gas-reporter": "^0.2.18-beta.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,6 @@
     "@nomiclabs/buidler": "^1.0.1"
   },
   "dependencies": {
-    "eth-gas-reporter": "^0.2.18-beta.0"
+    "eth-gas-reporter": "^0.2.18-beta.1"
   }
 }

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -3,33 +3,8 @@
 set -o errexit
 trap cleanup EXIT
 
-cleanup() {
-  if [ -n "$ganache_pid" ] && ps -p $ganache_pid > /dev/null; then
-    kill -9 $ganache_pid
-  fi
-
-  if [ -n "$buidlerevm_pid" ] && ps -p $buidlerevm_pid > /dev/null; then
-    kill -9 $buidlerevm_pid
-  fi
-}
-
-start_ganache() {
-  node_modules/.bin/ganache-cli > /dev/null &
-  ganache_pid=$!
-  sleep 4
-}
-
-start_buidlerevm() {
-  node_modules/.bin/buidler node > /dev/null &
-  buidlerevm_pid=$!
-  sleep 4
-}
-
-# Ganache tests
-start_ganache
+# Truffle tests
 npx mocha test/truffle.ts --timeout 100000 --exit
-cleanup
 
-# BuidlerEVM
-start_buidlerevm
+# Ethers tests
 npx mocha test/ethers.ts --timeout 100000 --exit

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 set -o errexit
-trap cleanup EXIT
 
 # Truffle tests
 npx mocha test/truffle.ts --timeout 100000 --exit

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,7 @@ export default function() {
         if (options.fast){
           bre.network.provider = createGasMeasuringProvider(bre.network.provider);
           mochaConfig.reporterOptions.provider = new AsyncProvider(bre.network.provider);
-          mochaConfig.reporterOptions.blockLimit = bre.network.config.blockGasLimit;
+          mochaConfig.reporterOptions.blockLimit = (<any>bre.network.config).blockGasLimit as number;
         }
 
         bre.config.mocha = mochaConfig;

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,7 @@ export default function() {
         if (options.fast){
           bre.network.provider = createGasMeasuringProvider(bre.network.provider);
           mochaConfig.reporterOptions.provider = new AsyncProvider(bre.network.provider);
+          mochaConfig.reporterOptions.blockLimit = bre.network.config.blockGasLimit;
         }
 
         bre.config.mocha = mochaConfig;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,0 +1,44 @@
+/**
+ * A set of async RPC calls which substitute the sync calls made by the core reporter
+ * These allow us to use BuidlerEVM or another in-process provider.
+ */
+
+import { IEthereumProvider } from "@nomiclabs/buidler/types";
+
+export default class AsyncProvider {
+  public provider: IEthereumProvider;
+
+  constructor(provider: IEthereumProvider) {
+    this.provider = provider;
+  }
+
+  async getNetworkId() {
+    return this.provider.send("net_version", []);
+  }
+
+  async getCode(address: string) {
+    return this.provider.send("eth_getCode", [address, "latest"]);
+  }
+
+  async getLatestBlock() {
+    return this.provider.send("eth_getBlockByNumber", ["latest", false]);
+  }
+
+  async getBlockByNumber(num: number) {
+    const hexNumber = `0x${num.toString(16)}`;
+    return this.provider.send("eth_getBlockByNumber", [hexNumber, true]);
+  }
+
+  async blockNumber() {
+    const block = await this.getLatestBlock();
+    return parseInt(block.number, 16);
+  }
+
+  async getTransactionByHash(tx) {
+    return this.provider.send("eth_getTransactionByHash", [tx]);
+  }
+
+  async call(payload, blockNumber) {
+    return this.provider.send("eth_call", [payload, blockNumber]);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,4 +16,5 @@ export interface EthGasReporterConfig {
   metadata: any;
   artifactType: any;
   url: string;
+  fast: boolean;
 }

--- a/test/buidler-truffle-project/buidler.config.js
+++ b/test/buidler-truffle-project/buidler.config.js
@@ -14,13 +14,6 @@ module.exports = {
       runs: 100
     }
   },
-  defaultNetwork: 'development',
-  networks: {
-    development: {
-      gas: 5000000,
-      url: "http://localhost:8545"
-    }
-  },
   gasReporter: {
     onlyCalledMethods: false
   }

--- a/test/ethers.ts
+++ b/test/ethers.ts
@@ -4,7 +4,7 @@ import { assert } from "chai";
 import { useEnvironment } from "./helpers";
 
 describe("Ethers plugin", function() {
-  useEnvironment(__dirname + "/buidler-ethers-project", "localhost");
+  useEnvironment(__dirname + "/buidler-ethers-project");
 
   it("no options", async function() {
     await this.env.run(TASK_TEST, { testFiles: [] });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -7,13 +7,12 @@ declare module "mocha" {
   }
 }
 
-export function useEnvironment(projectPath: string, networkName: string) {
+export function useEnvironment(projectPath: string) {
   let previousCWD: string;
 
   beforeEach("Loading buidler environment", function() {
     previousCWD = process.cwd();
     process.chdir(projectPath);
-    process.env.BUIDLER_NETWORK = networkName;
     this.env = require("@nomiclabs/buidler");
   });
 

--- a/test/truffle.ts
+++ b/test/truffle.ts
@@ -5,7 +5,7 @@ import { assert } from "chai";
 import { useEnvironment } from "./helpers";
 
 describe("Truffle plugin", function() {
-  useEnvironment(__dirname + "/buidler-truffle-project", "development");
+  useEnvironment(__dirname + "/buidler-truffle-project");
 
   it("default", async function() {
     this.env.config.gasReporter.onlyCalledMethods = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,10 +1582,10 @@ eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.0:
     idna-uts46-hx "^2.3.1"
     js-sha3 "^0.5.7"
 
-eth-gas-reporter@^0.2.17:
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.17.tgz#3ff12ae0235d97b429bcad3a1b05ce4d1a91d9be"
-  integrity sha512-MsrUqeXTAFU9QEdAIdaVu+QeU1XwFsKvPDEC68iheppVR5xUP11h4SyPhSRZiGfOzXr1CfTtPM/B6wPGtt7/LA==
+eth-gas-reporter@^0.2.18-beta.0:
+  version "0.2.18-beta.0"
+  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.18-beta.0.tgz#8a8f1a81d9ce4c8f757c75a70681e4d4138e6c9e"
+  integrity sha512-nXEiqy0a4Inl+ghq15hpu7rtF/FOzl/qw+52duvQmdl+gpgqwpFshgyOqZLlgSix/G9RhiWRB+HQHmb/uX7IVQ==
   dependencies:
     "@ethersproject/abi" "^5.0.0-beta.146"
     "@solidity-parser/parser" "^0.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,10 +1582,10 @@ eth-ens-namehash@2.0.8, eth-ens-namehash@^2.0.0:
     idna-uts46-hx "^2.3.1"
     js-sha3 "^0.5.7"
 
-eth-gas-reporter@^0.2.18-beta.0:
-  version "0.2.18-beta.0"
-  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.18-beta.0.tgz#8a8f1a81d9ce4c8f757c75a70681e4d4138e6c9e"
-  integrity sha512-nXEiqy0a4Inl+ghq15hpu7rtF/FOzl/qw+52duvQmdl+gpgqwpFshgyOqZLlgSix/G9RhiWRB+HQHmb/uX7IVQ==
+eth-gas-reporter@^0.2.18-beta.1:
+  version "0.2.18-beta.1"
+  resolved "https://registry.yarnpkg.com/eth-gas-reporter/-/eth-gas-reporter-0.2.18-beta.1.tgz#ba5682143395dd157d3060a0a1410e17a930d45c"
+  integrity sha512-Sia5aN6R27JqnvtDXgghbsLPLEpYkBafuwdIzf7gU5SnYYvn1TJuJ2MUGHEjqcyA7UqbkUZqEypltgt3TVD0Zg==
   dependencies:
     "@ethersproject/abi" "^5.0.0-beta.146"
     "@solidity-parser/parser" "^0.5.2"


### PR DESCRIPTION
Experimental...super fast but doesn't work correctly for an Ethers-based provider yet (the contract methods are missing).

Truffle-contract / Web3 stuff seems okay though.

(cf: [eth-gas-reporter 171][1])

[1]: https://github.com/cgewecke/eth-gas-reporter/issues/171