### PR TITLE
Add coinmarketcap to types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 export interface EthGasReporterConfig {
   currency?: string;
   gasPrice?: number;
+  coinmarketcap?: string;
   outputFile?: string;
   noColors?: boolean;
   onlyCalledMethods?: boolean;


### PR DESCRIPTION
The interface `EthGasReporterConfig` is missing `coinmarketcap`.
This PR adds `coinmarketcap?: string;` to `types.ts`