### PR TITLE
perf: strict typing for 'artifactType'

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export interface EthGasReporterConfig {
   // Buidler (required)
   enabled: boolean;
   metadata: any;
-  artifactType: any;
+  artifactType?: "truffle-v5" | "0xProject-v2" | "buidler-v1" | "ethpm";
   url: string;
   fast?: boolean;
 }


### PR DESCRIPTION
I first set the "buidler" value to the "artifactType" field but I got no gas report. I then looked up [artifactor.js][1] and found out that `artifactType` must be one of:

+ truffle-v5
+ 0xProject-v2
+ buidler-v1
+ ethpm

[1]: https://github.com/cgewecke/eth-gas-reporter/blob/bbf521f137407f106aeec44c730541dda6734ce3/lib/artifactor.js